### PR TITLE
fix: reverting kind version to 0.17.0

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -5,7 +5,7 @@ golang 1.21.0
 golangci-lint 1.54.0
 jq 1.6
 helm 3.12.2
-kind 0.20.0
+kind 0.17.0
 kubectl 1.27.4
 pre-commit 3.3.3
 tilt 0.33.3


### PR DESCRIPTION
## What does this PR do?

This PR reverts the kind version to 0.17.0.

Kind 0.20.0 isn't compatible with Rancher Desktop. It's up to us whether to leave it that way for the moment (until the issue is fixed) or not to worry about it. 

## Related issues

https://github.com/rancher-sandbox/rancher-desktop/issues/5363

## Checklist before merging

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have checked the [contributing document](../CONTRIBUTING.MD).
- [X] I have checked the existing [Pull Requests](https://github.com/nearform/initium-platform/pulls) to see whether someone else has raised a similar idea or question.
- [ ] I have added tests that prove my fix is effective or that my feature works.
