### PR TITLE
chore: grafana tests

### DIFF
--- a/tests/grafana_addon_test.go
+++ b/tests/grafana_addon_test.go
@@ -87,13 +87,16 @@ func TestHelmGrafanaAddon(t *testing.T) {
 	tunnel.ForwardPort(t)
 
 	healthCheck, err := http.NewRequest("GET", fmt.Sprintf("http://%s/healthz", tunnel.Endpoint()), nil)
+	if err != nil {
+		log.Fatalf("Error when building the request: %s", reqErr)
+	}
 
 	resp, reqErr := http.DefaultClient.Do(healthCheck)
 	if reqErr != nil {
-		log.Fatalf("Error when making the request %s", reqErr)
+		log.Fatalf("Error when making the request: %s", reqErr)
 	}
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		log.Fatalf("Grafana is not ready for metrics: status code %d", resp.StatusCode)
 	} else {
 		log.Print("Grafana is ready for metrics!")

--- a/tests/grafana_addon_test.go
+++ b/tests/grafana_addon_test.go
@@ -1,10 +1,14 @@
 package test
 
 import (
+	"fmt"
 	"log"
+	"net/http"
 	"testing"
 
 	_ "github.com/stretchr/testify/assert"
+
+	"github.com/gruntwork-io/terratest/modules/k8s"
 )
 
 func TestHelmGrafanaAddon(t *testing.T) {
@@ -46,7 +50,52 @@ func TestHelmGrafanaAddon(t *testing.T) {
 	}
 
 	waitUntilServicesAvailable(t, *helmOptions.KubectlOptions, []string{"grafana"})
+	waitUntilDeploymentsAvailable(t, *helmOptions.KubectlOptions, []string{"grafana"})
 
+	// valuesFile, err := os.ReadFile("../addons/grafana/values.yaml")
+
+	// if err != nil {
+	// 	log.Fatal(err)
+	// }
+
+	// yamlData := make(map[string]interface{})
+
+	// err = yaml.Unmarshal(valuesFile, &yamlData)
+
+	// if err != nil {
+	// 	log.Fatal(err)
+	// }
+
+	// grafanaSource, ok := yamlData["grafana-source"].(map[string]interface{})
+	// if !ok {
+	// 	log.Fatalf("Error accessing 'grafana-source' key")
+	// }
+
+	// adminPassword, ok := grafanaSource["adminPassword"].(string)
+	// if !ok {
+	// 	log.Fatalf("Error accessing 'adminPassword' key")
+	// }
+
+	grafanaKubectlOptions := k8s.NewKubectlOptions("", "", "grafana")
+
+	tunnel := k8s.NewTunnel(grafanaKubectlOptions, k8s.ResourceTypeService, "grafana", 0, 3000)
+	defer tunnel.Close()
+
+	tunnel.ForwardPort(t)
+
+	healthCheck, err := http.NewRequest("GET", fmt.Sprintf("http://%s/healthz", tunnel.Endpoint()), nil)
+	// healthCheck.Header.Add("Authorization", fmt.Sprintf("Basic %s", b64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("admin:%s", adminPassword)))))
+
+	resp, reqErr := http.DefaultClient.Do(healthCheck)
+	if reqErr != nil {
+		log.Fatalf("Error when making the request %s", reqErr)
+	}
+
+	if resp.StatusCode != 200 {
+		log.Fatalf("Grafana is not ready for metrics: status code %d", resp.StatusCode)
+	} else {
+		log.Print("Grafana is ready for metrics!")
+	}
 	// ----------------------------------
 
 	destroyHelmEnvironment(t, addonData, helmOptions)

--- a/tests/grafana_addon_test.go
+++ b/tests/grafana_addon_test.go
@@ -88,7 +88,7 @@ func TestHelmGrafanaAddon(t *testing.T) {
 
 	healthCheck, err := http.NewRequest("GET", fmt.Sprintf("http://%s/healthz", tunnel.Endpoint()), nil)
 	if err != nil {
-		log.Fatalf("Error when building the request: %s", reqErr)
+		log.Fatalf("Error when building the request: %s", err)
 	}
 
 	resp, reqErr := http.DefaultClient.Do(healthCheck)

--- a/tests/helpers.go
+++ b/tests/helpers.go
@@ -189,6 +189,12 @@ func waitUntilStatefulSetsAvailable(t *testing.T, kubectlOptions k8s.KubectlOpti
 	return readySS == len(statefulSets)
 }
 
+func waitUntilDeploymentsAvailable(t *testing.T, kubectlOptions k8s.KubectlOptions, deployments []string) {
+	for _, v := range deployments {
+		k8s.WaitUntilDeploymentAvailable(t, &kubectlOptions, v, 10, 30*time.Second)
+	}
+}
+
 func waitUntilLoadBalancerAvailable(t *testing.T, kubectlOptions k8s.KubectlOptions) {
 	for _, v := range k8s.ListServices(t, &kubectlOptions, v1.ListOptions{}) {
 		if v.Spec.Type == "LoadBalancer" {


### PR DESCRIPTION
## What does this PR do?

This PR adds a healthcheck endpoint request to Grafana, for checking if it is ready to receive metrics.
It doesn't make sense to check whether Prometheus is sending metrics to Grafana since these are unit tests. There isn't an endpoint to check if there are metrics in Grafana since Grafana itself doesn't store metrics, displays them.

The commented code is just to show that there's another way for healthchecking Grafana. But I'm not sure whether that would work with potential custom values that users can define when using the app of apps.

## Related issues

https://github.com/nearform/initium-platform/issues/160

## Checklist before merging

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have checked the [contributing document](../CONTRIBUTING.MD).
- [X] I have checked the existing [Pull Requests](https://github.com/nearform/initium-platform/pulls) to see whether someone else has raised a similar idea or question.
- [X] I have added tests that prove my fix is effective or that my feature works.
