### PR TITLE
feat: argocd custom helm chart values exposed as a release artifact

### DIFF
--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -18,5 +18,7 @@ jobs:
         run: |
           helm template manifests/bootstrap --set revision=${{ github.ref_name }} > app-of-apps.yaml
           ./scripts/upload-assets.sh ${{ github.repository }} app-of-apps.yaml ${{ github.ref }}
+          yq '.argocd-source' ./addons/argocd/values.yaml > argocd-helm-values.yaml
+          ./scripts/upload-assets.sh ${{ github.repository }} argocd-helm-values.yaml ${{ github.ref }}
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## What does this PR do?

In order to avoid the need to download the whole `initium-platform` repository just to install ArgoCD with custom values, additional artifact is being published to be used within `helm upgrade --install command` like below one:

```
helm upgrade --install argocd argo-cd \
  --repo https://argoproj.github.io/argo-helm \
  --values ./argocd-helm-values.yaml \
  --version 5.16.14 \
  --namespace argocd \
  --create-namespace
```

According to this [doc](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#tools) `yq` should be available on GH runner. 

Successfully tested on local, all works as expected (ArgoCD exluded from `tilt up`, installed with the above helm command).

When this one is merged and released we need to update the quick-start guides for all the clouds.

## Related issues

Closes https://github.com/nearform/initium/issues/15

## Checklist before merging

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have checked the [contributing document](../CONTRIBUTING.MD).
- [x] I have checked the existing [Pull Requests](https://github.com/nearform/initium-platform/pulls) to see whether someone else has raised a similar idea or question.
- [x] I have added tests that prove my fix is effective or that my feature works.
