### PR TITLE
ci: add support for initium-cli to renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,6 +19,15 @@
       "groupName": "Istio Helm Chart"
     }
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^.tools-versions$"],
+      "matchStrings": ["initium (?<currentValue>.*?)\\n"],
+      "depName": "nearform/initium-cli",
+      "datasource": "github-releases"
+    }
+  ],
   "platform": "github",
   "platformAutomerge": true,
   "prConcurrentLimit": 0,


### PR DESCRIPTION
## What does this PR do?

With this PR renovate will be able to bump the initium cli version in .tool-versions

## Checklist before merging

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have checked the [contributing document](../CONTRIBUTING.MD).
- [x] I have checked the existing [Pull Requests](https://github.com/nearform/initium-platform/pulls) to see whether someone else has raised a similar idea or question.
- [x] I have added tests that prove my fix is effective or that my feature works.
